### PR TITLE
fix(parseFormDataProperties): 如果schema中不存在properties的话,报错的问题进行修复

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -157,6 +157,10 @@ const parseBodyProperties = (properties: Properties): Param[] => {
 };
 
 const parseFormDataProperties = (properties: Properties): Param[] => {
+  // 兼容properties为空的模式.
+  if (!properties) {
+    return []
+  }
   return Object.keys(properties).map((name: string) => {
     const parameter = properties[name];
     return {


### PR DESCRIPTION
在我使用的场景中，后端给的schema不存在properties。导致代码直接保存，我检查到问题是可以兼容的，目前我兼容了。是可以继续生成api文件的。